### PR TITLE
Add organization and plugin name to required info

### DIFF
--- a/source/model/Device.py
+++ b/source/model/Device.py
@@ -17,13 +17,19 @@ class Device(ABC):
         """ The current id of the device"""
         return self._id
 
-    @property
+    @classmethod
     @abstractmethod
-    def name(self):
-        """ The name. So that we might identify different plugins by name """
+    def organization(self):
+        """ Return the organization name to which this plugin belongs"""
         pass
 
-    @property
+    @classmethod
+    @abstractmethod
+    def name(self):
+        """ The name. So that we might identify different plugins form the same organization """
+        pass
+
+    @classmethod
     @abstractmethod
     def plugin_type(self):
         """ The type of a device for example: Lock, Light"""
@@ -34,10 +40,25 @@ class Device(ABC):
         """ The activators of a device """
         return self._activators
 
-    @staticmethod
+    @classmethod
+    def get_default_required_info(cls):
+        """ Get the default information of this device """
+        default_info = cls.__get_standard_required_info()
+        extra_info = cls.get_extra_required_info()
+        total = default_info.copy()
+        total.update(extra_info)
+        return total
+
+    @classmethod
     @abstractmethod
-    def get_default_required_info():
+    def get_extra_required_info(cls) -> dict:
+        """ Return that part of the required information that is specific to each device"""
         pass
+
+    @classmethod
+    def __get_standard_required_info(cls):
+        """ Returns that required information that is needed for all devices"""
+        return {"organization": cls.organization(), "plugin": cls.name()}
 
     def add_activator(self, activator):
         """ Add an activator to a device """

--- a/source/plugins/hestia/dimmableLight/DimmableLight.py
+++ b/source/plugins/hestia/dimmableLight/DimmableLight.py
@@ -4,10 +4,15 @@ from .Dimmer import Dimmer
 
 
 class DimmableLight(Device):
+
     def __init__(self):
         super().__init__()
         super().add_activator(ActivateLight())
         super().add_activator(Dimmer())
+
+    @classmethod
+    def organization(self):
+        return "Hestia"
 
     @property
     def name(self):
@@ -17,7 +22,7 @@ class DimmableLight(Device):
     def plugin_type(self):
         return "Light"
 
-    @staticmethod
-    def get_default_required_info():
+    @classmethod
+    def get_extra_required_info(cls) -> dict:
         return {"ip": "127.0.0.1", "port": "0"}
 

--- a/source/plugins/hestia/simpleLock/SimpleLock.py
+++ b/source/plugins/hestia/simpleLock/SimpleLock.py
@@ -1,5 +1,5 @@
 from model.Device import Device
-from .ActivateLock import ActivateLock
+from plugins.hestia.simpleLock.ActivateLock import ActivateLock
 
 
 class SimpleLock(Device):
@@ -8,16 +8,19 @@ class SimpleLock(Device):
         super().__init__()
         super().add_activator(ActivateLock())
 
-    @property
-    def name(self):
+    @classmethod
+    def organization(cls):
+        return 'Hestia'
+
+    @classmethod
+    def name(cls):
         return "SimpleLock"
     
     @property
     def plugin_type(self):
         return "Lock"
 
-    @staticmethod
-    def get_default_required_info():
+    @classmethod
+    def get_extra_required_info(cls) -> dict:
         return {"ip": "127.0.0.1", "port": "0"}
-
 


### PR DESCRIPTION
Fixes #28.
Add the name and the organization of the plugin to the required info.
As the name and the organization is needed for all plugin the
implementation of this is done in the Device class.
This way, only that information that is different for that plugin is
added in the plugin.