### PR TITLE
Removed database from PluginManager init

### DIFF
--- a/source/logic/__init__.py
+++ b/source/logic/__init__.py
@@ -10,7 +10,7 @@ from util.BasePath import get_base_path
 _device_database = DeviceDatabase("devices")
 
 device_config = get_base_path() + "deviceConfig"
-_plugin_manager = PluginManager(device_config, _device_database)
+_plugin_manager = PluginManager(device_config)
 
 
 device_logic = DeviceCollectionLogic(_device_database, _plugin_manager)

--- a/source/pluginmanager/PluginManager.py
+++ b/source/pluginmanager/PluginManager.py
@@ -13,7 +13,7 @@ class PluginManager:
     It is used to get information about plugins and instantiate plugins.
     """
     
-    def __init__(self, device_config, database):
+    def __init__(self, device_config):
         self._plugins = json.load(open(device_config))
 
     def get_plugin(self, organization, plugin_name, required_info):

--- a/source/tests/logic_tests/devices/test_activator_logic.py
+++ b/source/tests/logic_tests/devices/test_activator_logic.py
@@ -7,7 +7,7 @@ from tests import test_util
 class TestActivatorLogic(unittest.TestCase):
     def setUp(self):
         self._database = test_util.get_database()
-        self._plugin_manager = test_util.get_plugin_manager(self._database)
+        self._plugin_manager = test_util.get_plugin_manager()
 
         req = self._plugin_manager.get_required_info_of("mock", "Lock")
         plugin = self._plugin_manager.get_plugin("mock", "Lock", req)

--- a/source/tests/logic_tests/devices/test_device_collection_logic.py
+++ b/source/tests/logic_tests/devices/test_device_collection_logic.py
@@ -11,7 +11,7 @@ class TestDeviceCollectionLogic(unittest.TestCase):
     def setUp(self):
         self._direct_database = MongoClient()["Hestia"]["testing"]
         self._database = test_util.get_database()
-        self._plugin_manager = test_util.get_plugin_manager(self._database)
+        self._plugin_manager = test_util.get_plugin_manager()
 
         self._logic = DeviceCollectionLogic(self._database, self._plugin_manager)
 

--- a/source/tests/test_util.py
+++ b/source/tests/test_util.py
@@ -7,6 +7,6 @@ def get_database():
     return DeviceDatabase("testing")
 
 
-def get_plugin_manager(database):
+def get_plugin_manager():
     test_config = get_base_path() + "tests/testing_deviceConfig"
-    return PluginManager(test_config, database)
+    return PluginManager(test_config)


### PR DESCRIPTION
There was still a left over of the separation of plugin manager and
database in the init of the plugin manager and some other files
where the plugin manager was initiated.